### PR TITLE
Fix concurrently modifying the client item properties

### DIFF
--- a/1.16/src/main/java/org/infernalstudios/nebs/NekosEnchantedBooks.java
+++ b/1.16/src/main/java/org/infernalstudios/nebs/NekosEnchantedBooks.java
@@ -53,14 +53,17 @@ public class NekosEnchantedBooks {
         Type type = new TypeToken<Map<String, Float>>(){}.getType();
         enchantmentMap = new Gson().fromJson(new BufferedReader(input), type);
 
-        ItemModelsProperties.register(Items.ENCHANTED_BOOK, new ResourceLocation("nebs:enchant"), (stack, world, entity) -> {
-            Map<Enchantment, Integer> map = EnchantmentHelper.getEnchantments(stack);
-            if (map.isEmpty() || enchantmentMap == null) {
-                return 0.0F;
-            }
+        // enqueue this part so we don't concurrently modify the client item properties
+        event.enqueueWork(() -> {
+            ItemModelsProperties.register(Items.ENCHANTED_BOOK, new ResourceLocation("nebs:enchant"), (stack, world, entity) -> {
+                Map<Enchantment, Integer> map = EnchantmentHelper.getEnchantments(stack);
+                if (map.isEmpty() || enchantmentMap == null) {
+                    return 0.0F;
+                }
 
-            String key = map.entrySet().iterator().next().getKey().getDescriptionId();
-            return enchantmentMap.getOrDefault(key, 0.0F);
+                String key = map.entrySet().iterator().next().getKey().getDescriptionId();
+                return enchantmentMap.getOrDefault(key, 0.0F);
+            });
         });
     }
 

--- a/1.17/src/main/java/org/infernalstudios/nebs/NekosEnchantedBooks.java
+++ b/1.17/src/main/java/org/infernalstudios/nebs/NekosEnchantedBooks.java
@@ -52,14 +52,17 @@ public class NekosEnchantedBooks {
         Type type = new TypeToken<Map<String, Float>>(){}.getType();
         enchantmentMap = new Gson().fromJson(new BufferedReader(input), type);
 
-        ItemProperties.register(Items.ENCHANTED_BOOK, new ResourceLocation("nebs:enchant"), (stack, world, entity, i) -> {
-            Map<Enchantment, Integer> map = EnchantmentHelper.getEnchantments(stack);
-            if (map.isEmpty() || enchantmentMap == null) {
-                return 0.0F;
-            }
+        // enqueue this part so we don't concurrently modify the client item properties
+        event.enqueueWork(() -> {
+            ItemProperties.register(Items.ENCHANTED_BOOK, new ResourceLocation("nebs:enchant"), (stack, world, entity, i) -> {
+                Map<Enchantment, Integer> map = EnchantmentHelper.getEnchantments(stack);
+                if (map.isEmpty() || enchantmentMap == null) {
+                    return 0.0F;
+                }
 
-            String key = map.entrySet().iterator().next().getKey().getDescriptionId();
-            return enchantmentMap.getOrDefault(key, 0.0F);
+                String key = map.entrySet().iterator().next().getKey().getDescriptionId();
+                return enchantmentMap.getOrDefault(key, 0.0F);
+            });
         });
     }
 

--- a/1.18/src/main/java/org/infernalstudios/nebs/NekosEnchantedBooks.java
+++ b/1.18/src/main/java/org/infernalstudios/nebs/NekosEnchantedBooks.java
@@ -52,14 +52,17 @@ public class NekosEnchantedBooks {
         Type type = new TypeToken<Map<String, Float>>(){}.getType();
         enchantmentMap = new Gson().fromJson(new BufferedReader(input), type);
 
-        ItemProperties.register(Items.ENCHANTED_BOOK, new ResourceLocation("nebs:enchant"), (stack, world, entity, i) -> {
-            Map<Enchantment, Integer> map = EnchantmentHelper.getEnchantments(stack);
-            if (map.isEmpty() || enchantmentMap == null) {
-                return 0.0F;
-            }
+        // enqueue this part so we don't concurrently modify the client item properties
+        event.enqueueWork(() -> {
+            ItemProperties.register(Items.ENCHANTED_BOOK, new ResourceLocation("nebs:enchant"), (stack, world, entity, i) -> {
+                Map<Enchantment, Integer> map = EnchantmentHelper.getEnchantments(stack);
+                if (map.isEmpty() || enchantmentMap == null) {
+                    return 0.0F;
+                }
 
-            String key = map.entrySet().iterator().next().getKey().getDescriptionId();
-            return enchantmentMap.getOrDefault(key, 0.0F);
+                String key = map.entrySet().iterator().next().getKey().getDescriptionId();
+                return enchantmentMap.getOrDefault(key, 0.0F);
+            });
         });
     }
 

--- a/1.19/src/main/java/org/infernalstudios/nebs/NekosEnchantedBooks.java
+++ b/1.19/src/main/java/org/infernalstudios/nebs/NekosEnchantedBooks.java
@@ -52,14 +52,17 @@ public class NekosEnchantedBooks {
         Type type = new TypeToken<Map<String, Float>>(){}.getType();
         enchantmentMap = new Gson().fromJson(new BufferedReader(input), type);
 
-        ItemProperties.register(Items.ENCHANTED_BOOK, new ResourceLocation("nebs:enchant"), (stack, world, entity, i) -> {
-            Map<Enchantment, Integer> map = EnchantmentHelper.getEnchantments(stack);
-            if (map.isEmpty() || enchantmentMap == null) {
-                return 0.0F;
-            }
+        // enqueue this part so we don't concurrently modify the client item properties
+        event.enqueueWork(() -> {
+            ItemProperties.register(Items.ENCHANTED_BOOK, new ResourceLocation("nebs:enchant"), (stack, world, entity, i) -> {
+                Map<Enchantment, Integer> map = EnchantmentHelper.getEnchantments(stack);
+                if (map.isEmpty() || enchantmentMap == null) {
+                    return 0.0F;
+                }
 
-            String key = map.entrySet().iterator().next().getKey().getDescriptionId();
-            return enchantmentMap.getOrDefault(key, 0.0F);
+                String key = map.entrySet().iterator().next().getKey().getDescriptionId();
+                return enchantmentMap.getOrDefault(key, 0.0F);
+            });
         });
     }
 

--- a/1.20/src/main/java/org/infernalstudios/nebs/NekosEnchantedBooks.java
+++ b/1.20/src/main/java/org/infernalstudios/nebs/NekosEnchantedBooks.java
@@ -52,17 +52,20 @@ public class NekosEnchantedBooks {
         Type type = new TypeToken<Map<String, Float>>(){}.getType();
         enchantmentMap = new Gson().fromJson(new BufferedReader(input), type);
 
-        ItemProperties.register(Items.ENCHANTED_BOOK, new ResourceLocation("nebs:enchant"), (stack, world, entity, i) -> {
-            Map<Enchantment, Integer> map = EnchantmentHelper.getEnchantments(stack);
-            if (map.isEmpty() || enchantmentMap == null) {
-                return 0.0F;
-            }
+        // enqueue this part so we don't concurrently modify the client item properties
+        event.enqueueWork(() -> {
+            ItemProperties.register(Items.ENCHANTED_BOOK, new ResourceLocation("nebs:enchant"), (stack, world, entity, i) -> {
+                Map<Enchantment, Integer> map = EnchantmentHelper.getEnchantments(stack);
+                if (map.isEmpty() || enchantmentMap == null) {
+                    return 0.0F;
+                }
 
-            String key = map.entrySet().iterator().next().getKey().getDescriptionId();
-            return enchantmentMap.getOrDefault(key, 0.0F);
+                String key = map.entrySet().iterator().next().getKey().getDescriptionId();
+                return enchantmentMap.getOrDefault(key, 0.0F);
+            });
         });
     }
-  
+
     private void gatherData(GatherDataEvent event) {
         DataGenerator gen = event.getGenerator();
 


### PR DESCRIPTION
This mod registers client-side item properties for enchanted books. Unfortunately, this item properties map is a global variable that can be accessed by any mod. Mod developers are supposed to use `FMLClientSetupEvent`, a parallel dispatch event, to enqueue work into the loader to make sure this doesn't happen, although I understand that it isn't very clear at time. This PR solves this problem by isolating the item properties registration to a queue in the event.

- Fixes #38.