### PR TITLE
Prevent loading the mod on the server

### DIFF
--- a/1.16/src/main/java/org/infernalstudios/nebs/NekosEnchantedBooks.java
+++ b/1.16/src/main/java/org/infernalstudios/nebs/NekosEnchantedBooks.java
@@ -7,6 +7,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Objects;
 
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.fml.DistExecutor;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -40,10 +42,14 @@ public class NekosEnchantedBooks {
     public NekosEnchantedBooks() {
         ModLoadingContext.get().registerExtensionPoint(ExtensionPoint.DISPLAYTEST,
                 () -> Pair.of(() -> FMLNetworkConstants.IGNORESERVERONLY, (a, b) -> true));
-        IEventBus bus = FMLJavaModLoadingContext.get().getModEventBus();
-        bus.addListener(this::doClientStuff);
-        bus.addListener(this::gatherData);
-        MinecraftForge.EVENT_BUS.register(this);
+
+        // Only load the mod on the client side
+        DistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> () -> {
+            IEventBus bus = FMLJavaModLoadingContext.get().getModEventBus();
+            bus.addListener(this::doClientStuff);
+            bus.addListener(this::gatherData);
+            MinecraftForge.EVENT_BUS.register(this);
+        });
     }
 
     private void doClientStuff(final FMLClientSetupEvent event) {

--- a/1.17/src/main/java/org/infernalstudios/nebs/NekosEnchantedBooks.java
+++ b/1.17/src/main/java/org/infernalstudios/nebs/NekosEnchantedBooks.java
@@ -7,6 +7,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Objects;
 
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.fml.DistExecutor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -39,10 +41,14 @@ public class NekosEnchantedBooks {
     public NekosEnchantedBooks() {
         ModLoadingContext.get().registerExtensionPoint(IExtensionPoint.DisplayTest.class,
                 () -> new IExtensionPoint.DisplayTest(() -> FMLNetworkConstants.IGNORESERVERONLY, (a, b) -> true));
-        IEventBus bus = FMLJavaModLoadingContext.get().getModEventBus();
-        bus.addListener(this::doClientStuff);
-        bus.addListener(this::gatherData);
-        MinecraftForge.EVENT_BUS.register(this);
+
+        // Only load the mod on the client side
+        DistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> () -> {
+            IEventBus bus = FMLJavaModLoadingContext.get().getModEventBus();
+            bus.addListener(this::doClientStuff);
+            bus.addListener(this::gatherData);
+            MinecraftForge.EVENT_BUS.register(this);
+        });
     }
 
     private void doClientStuff (final FMLClientSetupEvent event) {

--- a/1.18/src/main/java/org/infernalstudios/nebs/NekosEnchantedBooks.java
+++ b/1.18/src/main/java/org/infernalstudios/nebs/NekosEnchantedBooks.java
@@ -7,6 +7,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Objects;
 
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.fml.DistExecutor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -39,10 +41,14 @@ public class NekosEnchantedBooks {
     public NekosEnchantedBooks() {
         ModLoadingContext.get().registerExtensionPoint(IExtensionPoint.DisplayTest.class,
                 () -> new IExtensionPoint.DisplayTest(() -> NetworkConstants.IGNORESERVERONLY, (a, b) -> true));
-        IEventBus bus = FMLJavaModLoadingContext.get().getModEventBus();
-        bus.addListener(this::doClientStuff);
-        bus.addListener(this::gatherData);
-        MinecraftForge.EVENT_BUS.register(this);
+
+        // Only load the mod on the client side
+        DistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> () -> {
+            IEventBus bus = FMLJavaModLoadingContext.get().getModEventBus();
+            bus.addListener(this::doClientStuff);
+            bus.addListener(this::gatherData);
+            MinecraftForge.EVENT_BUS.register(this);
+        });
     }
 
     private void doClientStuff (final FMLClientSetupEvent event) {

--- a/1.19/src/main/java/org/infernalstudios/nebs/NekosEnchantedBooks.java
+++ b/1.19/src/main/java/org/infernalstudios/nebs/NekosEnchantedBooks.java
@@ -9,9 +9,11 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.item.enchantment.EnchantmentHelper;
+import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.data.event.GatherDataEvent;
 import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.fml.DistExecutor;
 import net.minecraftforge.fml.IExtensionPoint;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
@@ -39,10 +41,14 @@ public class NekosEnchantedBooks {
     public NekosEnchantedBooks() {
         ModLoadingContext.get().registerExtensionPoint(IExtensionPoint.DisplayTest.class,
                 () -> new IExtensionPoint.DisplayTest(() -> NetworkConstants.IGNORESERVERONLY, (a, b) -> true));
-        IEventBus bus = FMLJavaModLoadingContext.get().getModEventBus();
-        bus.addListener(this::doClientStuff);
-        bus.addListener(this::gatherData);
-        MinecraftForge.EVENT_BUS.register(this);
+
+        // Only load the mod on the client side
+        DistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> () -> {
+            IEventBus bus = FMLJavaModLoadingContext.get().getModEventBus();
+            bus.addListener(this::doClientStuff);
+            bus.addListener(this::gatherData);
+            MinecraftForge.EVENT_BUS.register(this);
+        });
     }
 
     private void doClientStuff (final FMLClientSetupEvent event) {

--- a/1.20/src/main/java/org/infernalstudios/nebs/NekosEnchantedBooks.java
+++ b/1.20/src/main/java/org/infernalstudios/nebs/NekosEnchantedBooks.java
@@ -9,9 +9,11 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.item.enchantment.EnchantmentHelper;
+import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.data.event.GatherDataEvent;
 import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.fml.DistExecutor;
 import net.minecraftforge.fml.IExtensionPoint;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
@@ -39,10 +41,14 @@ public class NekosEnchantedBooks {
     public NekosEnchantedBooks() {
         ModLoadingContext.get().registerExtensionPoint(IExtensionPoint.DisplayTest.class,
                 () -> new IExtensionPoint.DisplayTest(() -> NetworkConstants.IGNORESERVERONLY, (a, b) -> true));
-        IEventBus bus = FMLJavaModLoadingContext.get().getModEventBus();
-        bus.addListener(this::doClientStuff);
-        bus.addListener(this::gatherData);
-        MinecraftForge.EVENT_BUS.register(this);
+
+        // Only load the mod on the client side
+        DistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> () -> {
+            IEventBus bus = FMLJavaModLoadingContext.get().getModEventBus();
+            bus.addListener(this::doClientStuff);
+            bus.addListener(this::gatherData);
+            MinecraftForge.EVENT_BUS.register(this);
+        });
     }
 
     private void doClientStuff (final FMLClientSetupEvent event) {


### PR DESCRIPTION
While informing your audience that the mod is for client-side only, it is rather fruitless in today's modding-scape when mods are pretty much expected to behave properly whether or not they are on the client or server. Forge provides `DistExecutor` to help alleviate the problem of trying to figure out where you are and what to do. It is also a huge headache off of users and server owners, since the error given when crashing on server is not entirely obvious to server owners who are inexperienced when reading stacktraces and understanding certain exceptions.

- Fixes #46.